### PR TITLE
Add local dependency support

### DIFF
--- a/src/Dependency.zig
+++ b/src/Dependency.zig
@@ -24,24 +24,21 @@ const Source = union(SourceType) {
         repository: []const u8,
         ver_str: []const u8,
     },
-
     github: struct {
         user: []const u8,
         repo: []const u8,
         ref: []const u8,
         root: []const u8,
     },
-
     url: struct {
         str: []const u8,
         root: []const u8,
         //integrity: ?Integrity,
     },
-
     local: struct {
         path: []const u8,
         root: []const u8,
-    }
+    },
 };
 
 fn findLatestMatch(self: Self, lockfile: *Lockfile) ?*Lockfile.Entry {
@@ -257,12 +254,6 @@ pub fn fromZNode(node: *zzz.ZNode) !Self {
                         .{ src.url.str, err },
                     );
                 },
-                error.UnexpectedCharacter => {
-                    std.log.err(
-                        "Failed to parse '{s}' as a url ({}), did you forget 'file://' for defining a local path?",
-                        .{ src.url.str, err },
-                    );
-                },
                 else => return err,
             }
             return error.Explained;
@@ -306,7 +297,7 @@ fn expectDepEqual(expected: Self, actual: Self) void {
         .local => |local| {
             testing.expectEqualStrings(local.path, actual.src.local.path);
             testing.expectEqualStrings(local.root, actual.src.local.root);
-        }
+        },
     };
 }
 

--- a/src/Dependency.zig
+++ b/src/Dependency.zig
@@ -37,6 +37,11 @@ const Source = union(SourceType) {
         root: []const u8,
         //integrity: ?Integrity,
     },
+
+    local: struct {
+        path: []const u8,
+        root: []const u8,
+    }
 };
 
 fn findLatestMatch(self: Self, lockfile: *Lockfile) ?*Lockfile.Entry {
@@ -65,6 +70,8 @@ fn findLatestMatch(self: Self, lockfile: *Lockfile) ?*Lockfile.Entry {
                 mem.eql(u8, gh.root, entry.github.root)) return entry,
             .url => |url| if (mem.eql(u8, url.str, entry.url.str) and
                 mem.eql(u8, url.root, entry.url.root)) return entry,
+            .local => |local| if (mem.eql(u8, local.path, entry.local.path) and
+                mem.eql(u8, local.root, entry.local.root)) return entry,
         }
     }
 
@@ -106,6 +113,12 @@ fn resolveLatest(
             .url = .{
                 .str = url.str,
                 .root = url.root,
+            },
+        },
+        .local => |local| Lockfile.Entry{
+            .local = .{
+                .path = local.path,
+                .root = local.root,
             },
         },
     };
@@ -226,6 +239,12 @@ pub fn fromZNode(node: *zzz.ZNode) !Self {
                     .root = (try zFindString(node, "root")) orelse "src/main.zig",
                 },
             },
+            .local => .{
+                .local = .{
+                    .path = try zGetString(child.child orelse return error.UrlMissingStr),
+                    .root = (try zFindString(node, "root")) orelse "src/main.zig",
+                },
+            },
         };
     };
 
@@ -284,6 +303,10 @@ fn expectDepEqual(expected: Self, actual: Self) void {
             testing.expectEqualStrings(url.str, actual.src.url.str);
             testing.expectEqualStrings(url.root, actual.src.url.root);
         },
+        .local => |local| {
+            testing.expectEqualStrings(local.path, actual.src.local.path);
+            testing.expectEqualStrings(local.root, actual.src.local.root);
+        }
     };
 }
 
@@ -485,6 +508,47 @@ test "raw explicit root" {
     expectDepEqual(expected, actual);
 }
 
+test "local with default root" {
+    const actual = try fromString(
+        \\foo:
+        \\  src:
+        \\    local: "mypkgs/cool-project"
+    );
+
+    const expected = Self{
+        .alias = "foo",
+        .src = .{
+            .local = .{
+                .path = "mypkgs/cool-project",
+                .root = "src/main.zig",
+            },
+        },
+    };
+
+    expectDepEqual(expected, actual);
+}
+
+test "local with explicit root" {
+    const actual = try fromString(
+        \\foo:
+        \\  src:
+        \\    local: "mypkgs/cool-project"
+        \\  root: main.zig
+    );
+
+    const expected = Self{
+        .alias = "foo",
+        .src = .{
+            .local = .{
+                .path = "mypkgs/cool-project",
+                .root = "main.zig",
+            },
+        },
+    };
+
+    expectDepEqual(expected, actual);
+}
+
 test "pkg can't take a root" {
     // TODO
 }
@@ -547,6 +611,14 @@ pub fn addToZNode(
 
             if (explicit or !std.mem.eql(u8, url.root, "src/main.zig")) {
                 try zPutKeyString(tree, alias, "root", url.root);
+            }
+        },
+        .local => |local| {
+            var src = try tree.addNode(alias, .{ .String = "src" });
+            try zPutKeyString(tree, src, "local", local.path);
+
+            if (explicit or !std.mem.eql(u8, local.root, "src/main.zig")) {
+                try zPutKeyString(tree, alias, "root", local.root);
             }
         },
     }


### PR DESCRIPTION
While playing around with Zig and gyro I've found myself using a couple of libraries that had a few issues due to changes to the compiler and language; the compile -> fix -> compile loop was slow because 1) the compiler only checks code that is actually used and 2) I couldn't figure out a nice way of making gyro fetch my local changes using `url` only.

This set of changes make it possible to define a dependency on a local, relative path:
```zzz
foo:
  src:
    local: "../mypkgs/cool-project"
  root: main.zig
```

All this does is symlink the given path into `.gyro/<some hash>/pkg`, making any changes to the source folder instantly visible to the compiler.

I'm new to Zig and I'm also not completely sure this is the best approach for this, so I've tried to keep the existing style and ensuring that things work mostly with manual tests. All feedback is more than welcome.