### PR TITLE
Fix README to refer to .gyro/ rather than ./gyro/

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ This is the generated file that's imported by `build.zig`, it can be imported
 with `@import("deps.zig")` or `@import("gyro")`. Unless you are vendoring your
 dependencies, this should should be added to `.gitignore`.
 
-### ./gyro/
+### .gyro/
 
 This directory holds the source code of all your dependencies. Path names are
 human readable and look something like `<package>-<user>-<hash>` so in many


### PR DESCRIPTION
I just ran the following and found packages seem to be installed in `.gyro/` rather than `gyro/`, as mentioned in the README. Pretty small thing but thought worth tidying up.

```
$gyro init
$gyro add LewisGaul/nestedtext
$gyro fetch
info: fetching tarball: https://astrolabe.pm/archive/LewisGaul/nestedtext/0.1.0
$ls -a
./  ../  .gyro/  gyro.lock  gyro.zzz