### PR TITLE
Auto-convert line endings to CRLF on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zig text eol=lf


### PR DESCRIPTION
After your latest fix regarding POSIX path, I could not build Gyro (master) on windows due to the missing conversion of line endings to CRLF.
The problem does not appear on the Windows build triggered by Github Actions thanks to the use of `actions/checkout@v2` which does the conversion automatically (cf: [goto-bus-stop/setup-zig README](https://github.com/goto-bus-stop/setup-zig))

```
λ zig build test
C:\Users\DEV\Documents\Code\gyro\src\completion.zig:101:32: error: expected ',', found invalid bytes
                \\#compdef gyro
                               ^
C:\Users\DEV\Documents\Code\gyro\src\completion.zig:102:3: note: invalid byte: ' '
                \\
  ^
C:\Users\DEV\Documents\Code\gyro\src\Dependency.zig:321:21: error: expected ',', found invalid bytes
        \\something:
                    ^
C:\Users\DEV\Documents\Code\gyro\src\Dependency.zig:322:9: note: invalid byte: '\\'
        \\  src:
        ^
C:\Users\DEV\Documents\Code\gyro\src\commands.zig:334:16: error: expected ',', found invalid bytes
        \\pkgs:
               ^
C:\Users\DEV\Documents\Code\gyro\src\commands.zig:335:9: note: invalid byte: '\\'
        \\  {s}:
        ^
The following command exited with error code 1:
```

The PR does not make it work yet, as the same problem happens with `mattnite/zzz`.
I also made a PR (https://github.com/mattnite/zzz/pull/3) to fix it. If it is accepted, I will upgrade zzz in another commit :) 