### PR TITLE
Ignore unknown fields in `zig env`

### DIFF
--- a/src/commands.zig
+++ b/src/commands.zig
@@ -195,7 +195,7 @@ pub fn build(allocator: Allocator, args: *std.process.ArgIterator) !void {
     }
 
     var token_stream = std.json.TokenStream.init(result.stdout);
-    const parse_opts = std.json.ParseOptions{ .allocator = allocator };
+    const parse_opts = std.json.ParseOptions{ .allocator = allocator, .ignore_unknown_fields = true };
     const env = try std.json.parse(EnvInfo, &token_stream, parse_opts);
     defer std.json.parseFree(EnvInfo, env, parse_opts);
 


### PR DESCRIPTION
In latest zig master `zig env` includes an extra field, target.
```
$ zig env
{
 "zig_exe": "/home/lee/zig/0.10.0-dev.4176+6d7b0690a/files/zig",
 "lib_dir": "/home/lee/zig/0.10.0-dev.4176+6d7b0690a/files/lib",
 "std_dir": "/home/lee/zig/0.10.0-dev.4176+6d7b0690a/files/lib/std",
 "global_cache_dir": "/home/lee/.cache/zig",
 "version": "0.10.0-dev.4176+6d7b0690a",
 "target": "x86_64-linux.5.19.10...5.19.10-gnu.2.36"
}
```

Without this change:
```
$ gyro build -h
/home/lee/zig/0.10.0-dev.4176+6d7b0690a/files/lib/std/json.zig:1579:33: 0x45b11e in parseInternal__anon_31404 (gyro)
                                return error.UnknownField;
                                ^
/home/lee/zig/0.10.0-dev.4176+6d7b0690a/files/lib/std/json.zig:1714:15: 0x410883 in parse__anon_22527 (gyro)
    const r = try parseInternal(T, token, tokens, options);
              ^
/home/lee/src/gyro/src/commands.zig:199:17: 0x40e1a9 in build (gyro)
    const env = try std.json.parse(EnvInfo, &token_stream, parse_opts);
                ^
/home/lee/src/gyro/src/main.zig:242:13: 0x411ee6 in run__anon_21508 (gyro)
            try cmds.build(allocator, iterator);
            ^
/home/lee/src/gyro/src/main.zig:144:13: 0x427836 in runCommands (gyro)
            try cmd.run(allocator, &args, &iter);
            ^
/home/lee/src/gyro/src/main.zig:64:25: 0x429447 in main (gyro)
                else => return err,
                        ^
```