### PR TITLE
Add nix flake build

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# If we are a computer with nix-shell available, then use that to setup
+# the build environment with exactly what we need.
+if has nix; then
+  use nix
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build_runner.zig
 .gyro/redirects
 tests/.gyro
 tests/deps.zig
-result/
+result

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build_runner.zig
 .gyro/redirects
 tests/.gyro
 tests/deps.zig
+result/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670538458,
+        "narHash": "sha256-mvKmBkdlhzsMBtnzYXjYn08EGw9rFBEE9hp4Uqgol1Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "99ec06122f481588abafd91f2710d80a5320efe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1661151577,
+        "narHash": "sha256-++S0TuJtuz9IpqP8rKktWyHZKpgdyrzDFUXVY07MTRI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54060e816971276da05970a983487a25810c38a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils",
+        "zig": "zig"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1670545432,
+        "narHash": "sha256-aVdVhuFm/J45W8K887/vIvKzJPLnhiBkIJMlbWBLgWA=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "0e3e713a8ba413d9b1268a9dba52420435aa6e6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
 
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = with pkgs; [ ];
-        buildInputs = with pkgs; [ z gyro ];
+        buildInputs = with pkgs; [ z ];
       };
 
       devShell = self.devShells.${system}.default;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "A package manager for the Zig programming language.";
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
+    zig.url     = github:mitchellh/zig-overlay;
+    utils.url   = github:numtide/flake-utils;
+
+    # Used for shell.nix
+    flake-compat = {
+      url = github:edolstra/flake-compat;
+      flake = false;
+    };
+  };
+
+  outputs = {self, nixpkgs, zig, utils, ...} @ inputs: with utils.lib;
+    eachSystem allSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          (final: prev: {
+            zigpkgs = inputs.zig.packages.${prev.system};
+          })
+        ];
+      };
+
+      # Our supported systems are the same supported systems as the Zig binaries
+      systems = builtins.attrNames inputs.zig.packages;
+
+      pname = "gyro";
+      version = "0.7.0";
+
+      gyro = pkgs.stdenv.mkDerivation {
+        inherit pname version;
+        src = ./.;
+        nativeBuildInputs = with pkgs; [
+          git
+          mercurial
+          wget
+          unzip
+          gnutar
+          zigpkgs.master
+          pkg-config
+        ];
+        buildInputs = with pkgs; [ ];
+        dontConfigure = true;
+        preBuild = ''
+          export HOME=$TMPDIR
+        '';
+
+        installPhase = ''
+          runHook preInstall
+          zig build -Drelease-safe
+          runHook postInstall
+        '';
+
+        installFlags = ["DESTDIR=$(out)"];
+
+        meta = {
+          maintainers = [ "Jake Chvatal <jake@isnt.online>" ];
+          description = "gyro";
+        };
+      };
+
+    in rec {
+      packages = {
+        gyro = gyro;
+        default = gyro;
+      };
+
+      defaultPackage = gyro;
+
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [
+          zigpkgs.master
+        ];
+
+        buildInputs = with pkgs; [
+          git
+          mercurial
+          wget
+          unzip
+          gnutar
+        ];
+      };
+
+      devShell = self.devShells.${system}.default;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A package manager for the Zig programming language.";
+  description = "A Zig package manager with an index, build runner, and build dependencies.";
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
     zig.url     = github:mitchellh/zig-overlay;
@@ -14,11 +14,13 @@
 
   outputs = {self, nixpkgs, zig, utils, ...} @ inputs: with utils.lib;
     eachSystem allSystems (system: let
+
       pkgs = import nixpkgs {
         inherit system;
         overlays = [
           (final: prev: {
             zigpkgs = inputs.zig.packages.${prev.system};
+            # zig = inputs.zig.packages.${zigVersion}.${prev.system};
           })
         ];
       };
@@ -29,35 +31,33 @@
       pname = "gyro";
       version = "0.7.0";
 
+      zigVersion = "0.10.0";
+      z = pkgs.zigpkgs.${zigVersion};
+
       gyro = pkgs.stdenv.mkDerivation {
         inherit pname version;
         src = ./.;
-        nativeBuildInputs = with pkgs; [
-          git
-          mercurial
-          wget
-          unzip
-          gnutar
-          zigpkgs.master
-          pkg-config
-        ];
+        nativeBuildInputs = with pkgs; [ z ];
         buildInputs = with pkgs; [ ];
         dontConfigure = true;
+
         preBuild = ''
           export HOME=$TMPDIR
         '';
 
         installPhase = ''
           runHook preInstall
-          zig build -Drelease-safe
+          zig build -Drelease-safe --prefix $out install
           runHook postInstall
         '';
 
         installFlags = ["DESTDIR=$(out)"];
 
-        meta = {
-          maintainers = [ "Jake Chvatal <jake@isnt.online>" ];
-          description = "gyro";
+        meta = with pkgs.lib; {
+          description = "A Zig package manager with an index, build runner, and build dependencies.";
+          license = licenses.mit;
+          platforms = platforms.linux;
+          maintainers = with maintainers; [ jakeisnt ];
         };
       };
 
@@ -70,17 +70,8 @@
       defaultPackage = gyro;
 
       devShells.default = pkgs.mkShell {
-        nativeBuildInputs = with pkgs; [
-          zigpkgs.master
-        ];
-
-        buildInputs = with pkgs; [
-          git
-          mercurial
-          wget
-          unzip
-          gnutar
-        ];
+        nativeBuildInputs = with pkgs; [ ];
+        buildInputs = with pkgs; [ z gyro ];
       };
 
       devShell = self.devShells.${system}.default;

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix


### PR DESCRIPTION
Adds [nix flake support](https://nixos.wiki/wiki/Flakes) to this repo. 

Flakes already have some nix ecosystem support;  Mitchell Hashimoto has a managed [zig compiler build here, for example](https://github.com/mitchellh/zig-overlay).

Concretely, this work provides a local development environment (accessible via `nix shell`) which pins the `zig` compiler version to 0.10.0, necessary to build it. The instructions from the `gyro` derivation can be copied into `nixpkgs` to make `gyro` available in the repository, but until then others can include this repository as a nix flake in their builds to install it, just as this flake includes a flake that pins the zig compiler.